### PR TITLE
fix: show default quantity for each SKU item in list

### DIFF
--- a/components/data/SkuListProvider/index.tsx
+++ b/components/data/SkuListProvider/index.tsx
@@ -63,7 +63,13 @@ export const SkuListProvider: FC<SkuListProviderProps> = ({
       const skuList = await cl.sku_lists.retrieve(skuListId, {
         include: ["sku_list_items", "skus"],
         fields: {
-          sku_lists: ["name", "description", "sku_list_items", "skus"],
+          sku_lists: [
+            "name",
+            "description",
+            "sku_list_items",
+            "skus",
+            "manual",
+          ],
           sku_list_items: ["sku_code", "quantity"],
           skus: ["code"],
         },

--- a/specs/e2e/cart-enabled.spec..ts
+++ b/specs/e2e/cart-enabled.spec..ts
@@ -39,7 +39,7 @@ test.describe("With inline cart feature enabled", () => {
     microstorePage,
   }) => {
     await microstorePage.addItemToCart({ inline: true })
-    await microstorePage.checkCartItemsCount(1)
+    await microstorePage.checkCartItemsCount(12)
     await microstorePage.expectCartLinkOnTop()
   })
 
@@ -47,7 +47,7 @@ test.describe("With inline cart feature enabled", () => {
     microstorePage,
   }) => {
     await microstorePage.addItemToCart({ inline: true })
-    await microstorePage.checkCartItemsCount(1)
+    await microstorePage.checkCartItemsCount(12)
 
     // validate cart url
     const carlUrl =

--- a/specs/e2e/quantity-selector.spec.ts
+++ b/specs/e2e/quantity-selector.spec.ts
@@ -10,8 +10,9 @@ test.describe("With quantity selector, for specific sku", () => {
   })
 
   test("should add default quantity to cart", async ({ microstorePage }) => {
+    await microstorePage.expectDefaultQuantity(12)
     await microstorePage.addItemToCart({ inline: true })
-    await microstorePage.checkCartItemsCount(1)
+    await microstorePage.checkCartItemsCount(12)
   })
 
   test("should be able to manually update quantity", async ({

--- a/specs/fixtures/MicrostorePage.ts
+++ b/specs/fixtures/MicrostorePage.ts
@@ -75,6 +75,11 @@ export class MicrostorePage {
     }
   }
 
+  async expectDefaultQuantity(quantity: number) {
+    const inputValue = await this.quantitySelector.inputValue()
+    await expect(inputValue).toBe(`${quantity}`)
+  }
+
   async addItemToCart({ inline }: { inline: boolean }) {
     if (inline) {
       await this.addToCartInlineButton.click()


### PR DESCRIPTION
### What does this PR do?
This fixes the pre-selection of the default quantity if a specific quantity has been set for each single `sku` in the list.
