### PR TITLE
Fix url for cart redirect when buy mode is active

### DIFF
--- a/components/utils/makeHostedAppUrl.test.ts
+++ b/components/utils/makeHostedAppUrl.test.ts
@@ -15,11 +15,11 @@ describe("makeHostedAppUrl", () => {
   })
 
   test("should return a valid hosted cart url", () => {
-    // mock window.location.href
+    // mock window.location
     global.window = Object.create(window)
     Object.defineProperty(window, "location", {
       value: {
-        href: "http://myorg.commercelayer.app/microstore?someUrlParam=xxxx",
+        origin: "http://myorg.commercelayer.app",
       },
     })
 

--- a/components/utils/makeHostedAppUrl.ts
+++ b/components/utils/makeHostedAppUrl.ts
@@ -40,4 +40,4 @@ const makeCheckoutUrl = ({
   )
 
 const makeCartUrl = ({ orderId }: { orderId: string }): URL =>
-  new URL(`cart/${orderId}`, window.location.href)
+  new URL(`cart/${orderId}`, window.location.origin)


### PR DESCRIPTION
### What does this PR do?
Cart URL now is properly built from current `location.origin`, while before we were using `location.href`.

